### PR TITLE
implementation of TD calculation in m_spectra.f90 file

### DIFF
--- a/src/m_spectra.f90
+++ b/src/m_spectra.f90
@@ -61,9 +61,25 @@ subroutine optical_spectrum(basis,occupation,c_matrix,chi,xpy_matrix,xmy_matrix,
   integer                            :: parityi,parityj,reflectioni,reflectionj
   character(len=32)                  :: symsymbol
   character(len=6)                   :: char6
+!=====TransDens
+ integer                            :: iexcit1,iexcit2,iexcit, ixxxx
+ integer                            :: idataxpy,icubefile
+ logical                            :: file_exists
+ character(len=200)                 :: file_name
+ real(dp)                           :: new_xpy(2*chi%npole_reso)
+ real(dp)                           :: each_transdens
+ integer,allocatable                :: icubetrans(:)
+ real(dp),allocatable               :: phi(:,:),transDens(:)
+ real(dp),parameter                 :: length=3.499470_dp
+ real(dp)                           :: rr(3)
+ real(dp)                           :: u(3),a(3)
+ real(dp)                           :: xmin,xmax,ymin,ymax,zmin,zmax
+ real(dp)                           :: dx,dy,dz
+ integer                            :: nx,ny,nz,ntot
+ integer                            :: ix,iy,iz,iatom,igrid
+ real(dp)                           :: basis_function_r(basis%nbf)
+ real(dp)                           :: start, finish, start2, finish2, start3, finish3
   !=====
-
-
   call start_clock(timing_spectrum)
   !
   ! Calculate the spectrum now
@@ -144,6 +160,24 @@ subroutine optical_spectrum(basis,occupation,c_matrix,chi,xpy_matrix,xmy_matrix,
 
   trk_sumrule=0.0_dp
   mean_excitation=0.0_dp
+
+!------TransDens
+ inquire(file='manual_cubetrans',exist=file_exists)
+ if(file_exists) then
+   open(newunit=icubefile,file='manual_cubetrans',status='old')
+   read(icubefile,*) iexcit1,iexcit2
+   read(icubefile,*) nx,ny,nz
+   close(icubefile)
+ else
+   iexcit1=0
+   iexcit2=0
+ endif
+
+ allocate(icubetrans(nexc))
+ do ixxxx = 1, nexc
+   icubetrans(ixxxx) = abs(icubetrans(ixxxx)) 
+ end do
+
   do t_jb_global=1,nexc
     t_jb = colindex_global_to_local('S',t_jb_global)
 
@@ -213,7 +247,9 @@ subroutine optical_spectrum(basis,occupation,c_matrix,chi,xpy_matrix,xmy_matrix,
 
       !
       ! Output the transition coefficients
+!     allocate(new_xpy(2*chi%npole_reso))
       coeff(:) = 0.0_dp
+      new_xpy(:) = 0.0_dp
       do t_ia=1,m_x
         t_ia_global = rowindex_local_to_global('S',t_ia)
         istate = chi%transition_table(1,t_ia_global)
@@ -221,12 +257,74 @@ subroutine optical_spectrum(basis,occupation,c_matrix,chi,xpy_matrix,xmy_matrix,
         if( t_jb /= 0 ) then
           ! Resonant
           coeff(                 t_ia_global) = 0.5_dp * ( xpy_matrix(t_ia,t_jb) + xmy_matrix(t_ia,t_jb) ) / SQRT(2.0_dp)
+          new_xpy(                   t_ia_global) = xpy_matrix(t_ia,t_jb)
           ! Anti-Resonant
           coeff(chi%npole_reso + t_ia_global) = 0.5_dp * ( xpy_matrix(t_ia,t_jb) - xmy_matrix(t_ia,t_jb) ) / SQRT(2.0_dp)
         endif
       enddo
       call world%sum(coeff)
+      call world%sum(new_xpy)
+!------TransDens 
+       if(iexcit1 <= t_jb_global .AND. t_jb_global <= iexcit2) then
+        iaspin = 1
+        xmin =MIN(MINVAL( xatom(1,:) ),MINVAL( xbasis(1,:) )) - length
+        xmax =MAX(MAXVAL( xatom(1,:) ),MAXVAL( xbasis(1,:) )) + length
+        ymin =MIN(MINVAL( xatom(2,:) ),MINVAL( xbasis(2,:) )) - length
+        ymax =MAX(MAXVAL( xatom(2,:) ),MAXVAL( xbasis(2,:) )) + length
+        zmin =MIN(MINVAL( xatom(3,:) ),MINVAL( xbasis(3,:) )) - length
+        zmax =MAX(MAXVAL( xatom(3,:) ),MAXVAL( xbasis(3,:) )) + length
+        dx = (xmax-xmin)/REAL(nx,dp)
+        dy = (ymax-ymin)/REAL(ny,dp)
+        dz = (zmax-zmin)/REAL(nz,dp)
+        ntot = nx * ny * nz
+        allocate(phi(basis%nbf,nspin))
+        allocate(transDens(ntot))
+         if( is_iomaster ) then
+           write(file_name,'(a,i2.2,a)') 'trans-density_',t_jb_global,'.cube'
+           open(newunit=icubetrans(t_jb_global),file=file_name)
+           write(icubetrans(t_jb_global),'(a,i4)') 'cube file generated from MOLGW',t_jb_global
+           write(icubetrans(t_jb_global),'(a,i4)') 'Transition density for excitation number',t_jb_global
+           write(icubetrans(t_jb_global),'(i6,3(f12.6,2x))') natom,xmin,ymin,zmin
+           write(icubetrans(t_jb_global),'(i6,3(f12.6,2x))') nx,dx,0.,0.
+           write(icubetrans(t_jb_global),'(i6,3(f12.6,2x))') ny,0.,dy,0.
+           write(icubetrans(t_jb_global),'(i6,3(f12.6,2x))') nz,0.,0.,dz
+         end if
+     
+         do iatom=1,natom
+           write(icubetrans(t_jb_global),'(i6,4(2x,f12.6))') NINT(zatom(iatom)),0.0,xatom(:,iatom)
+         enddo
+         igrid=0.0_dp
+         do ix=1,nx
+          rr(1) = xmin + (ix-1)*dx
+          do iy=1,ny
+           rr(2) = ymin + (iy-1)*dy
+           do iz=1,nz
+            rr(3) = zmin + (iz-1)*dz
+            igrid=1+igrid
+            transDens(igrid)= 0.0_dp
+     
+            call calculate_basis_functions_r(basis,rr,basis_function_r)
+            phi(:,iaspin) = MATMUL( basis_function_r(:) , c_matrix(:,:,iaspin) )
+     
+            do t_ia_global=1,chi%npole_reso
+             istate = chi%transition_table(1,t_ia_global)
+             astate = chi%transition_table(2,t_ia_global)
+             each_transdens = new_xpy(t_ia_global) * phi(istate,iaspin) * phi(astate,iaspin)
+             transDens(igrid) = transDens(igrid) + each_transdens
+            enddo      !t_ia_global
+     
+           enddo      !iz
+          enddo      !iy
+         enddo      !ix
+     
+           do igrid=1,ntot
+              write(icubetrans(t_jb_global),'(e16.8)') SQRT(2.0_dp) * transDens(igrid)
+           enddo
+         close (idataxpy)
+        deallocate(phi, transDens)
 
+         close (icubetrans(t_jb_global))
+       endif    !(iexcit == t_jb_global)
 
       do t_ia_global=1,chi%npole_reso
         istate = chi%transition_table(1,t_ia_global)
@@ -247,7 +345,7 @@ subroutine optical_spectrum(basis,occupation,c_matrix,chi,xpy_matrix,xmy_matrix,
   !
   ! For some calculation conditions, the rest of the subroutine is irrelevant
   ! So skip it! Skip it!
-  if( is_triplet ) then
+  if( is_triplet .OR. nexc /= chi%npole_reso ) then
     deallocate(residue)
     return
   endif
@@ -354,8 +452,6 @@ subroutine stopping_power(basis,c_matrix,chi,xpy_matrix,eigenvalue)
   integer                            :: nstate,m_x,n_x
   integer,parameter                  :: nqradial = 500
   real(dp),parameter                 :: dqradial = 0.02_dp
-!  integer,parameter                  :: nqradial = 1500
-!  real(dp),parameter                 :: dqradial = 0.01_dp
   integer,parameter                  :: nq = nqradial
   integer                            :: gt
   integer                            :: t_ia,t_jb
@@ -496,9 +592,6 @@ subroutine stopping_power(basis,c_matrix,chi,xpy_matrix,eigenvalue)
           if( NORM2(qvec) > eigenvalue(t_ia) / vv )   &
                stopping_cross_section(iv) = stopping_cross_section(iv) + ( 4.0_dp * pi ) / vv**2  &
                                               * fnq(t_ia)  / NORM2(qvec) * wq(iq) !&
-          !if( NORM2(qvec) > eigenvalue(t_ia) / vv )   &
-          !     stopping_exc(iv,t_ia) = stopping_exc(iv,t_ia) + ( 4.0_dp * pi ) / vv**2  &
-          !                                    * fnq(t_ia)  / NORM2(qvec) * wq(iq) !&
         enddo
 
       enddo
@@ -533,8 +626,8 @@ subroutine stopping_power(basis,c_matrix,chi,xpy_matrix,eigenvalue)
   !enddo
   !do iv=1,nvel_projectile
   !  vv = NORM2(vlist(:,iv))
-  !  do t_ia=1,12 ! nmat
-  !    write(stdout,'(i6,1x,2(2x,f12.6))') t_ia,vv,stopping_exc(iv,t_ia)
+  !  do t_ia=1,nmat
+  !    write(2000+t_ia,'(2(2x,f12.6))') vv,stopping_exc(iv,t_ia)
   !  enddo
   !enddo
 
@@ -577,7 +670,7 @@ subroutine stopping_power_3d(basis,c_matrix,chi,xpy_matrix,desc_x,eigenvalue)
   real(dp)                           :: qvec(3),qq
   integer                            :: iv
   real(dp)                           :: stopping_cross_section(nvel_projectile)
-  real(dp)                           :: stopping_exc(nvel_projectile,chi%npole_reso)
+  !real(dp)                           :: stopping_exc(nvel_projectile,chi%npole_reso)
   integer                            :: stride
   integer                            :: nq_batch
   integer                            :: fstopping
@@ -631,7 +724,7 @@ subroutine stopping_power_3d(basis,c_matrix,chi,xpy_matrix,desc_x,eigenvalue)
   call cross_product(v1,v3,v2)
   v2(:) = -v2(:)
 
-  stopping_exc(:,:) = 0.0_dp
+  stopping_cross_section(:) = 0.0_dp
   do iv=1,nvel_projectile
     write(stdout,*) 'iv/nvel_projectile',iv,' / ',nvel_projectile
     vv = NORM2(vlist(:,iv))
@@ -684,7 +777,7 @@ subroutine stopping_power_3d(basis,c_matrix,chi,xpy_matrix,desc_x,eigenvalue)
           deallocate(gos_mo)
           fnq = 2.0_dp * ABS( gos_tddft )**2 * eigenvalue(t_jb) / SUM( qvec(:)**2 )
 
-          stopping_exc(iv,t_jb) = stopping_exc(iv,t_jb) + 2.0_dp / vv**2  &
+          stopping_cross_section(iv) = stopping_cross_section(iv) + 2.0_dp / vv**2  &
                                               * fnq  * dphi * dcostheta    / ABS(costheta)
 
         enddo
@@ -693,8 +786,7 @@ subroutine stopping_power_3d(basis,c_matrix,chi,xpy_matrix,desc_x,eigenvalue)
     enddo
   enddo ! velocity
 
-  call world%sum(stopping_exc)
-  stopping_cross_section(:) = SUM(stopping_exc(:,:),DIM=2)
+  call world%sum(stopping_cross_section)
 
   call clean_deallocate('temporary non-distributed X+Y matrix',xpy_matrix_global)
 
@@ -706,9 +798,6 @@ subroutine stopping_power_3d(basis,c_matrix,chi,xpy_matrix,desc_x,eigenvalue)
   enddo
   write(stdout,*)
   close(fstopping)
-  do iv=1,nvel_projectile
-    write(stdout,'(*(2x,es18.8))') vlist(:,iv),stopping_cross_section(iv),stopping_exc(iv,1:20)
-  enddo
 
 
   if( print_yaml_ .AND. is_iomaster )  then


### PR DESCRIPTION
The Transition Density (TD) calculation has been implemented in the file 'm_spectra.f90' and a specific input variable did not define for it. 
- The TDs will print out for a set of desirable excitations in '.cube' format with the name: 'trans-density_...cube'
- For creating cube files, code follows the same procedure as wavefunction cube files.
- In the folder of calculation, code looks for the file 'manual_cubetrans', and if the file does not exist, code procced without calculating TDs.
- The first line in the 'manual_cubetrans' file indicates the beginning and end of the excitation range which TD should be calculated for, and second line represents desirable gride numbers in x, y, and z-direction. 
- The accuracy of calculations is comparable with other ab initio software packages such as TURBOMOLE.